### PR TITLE
test: update tests to run against WebdriverIO v7

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,14 +31,13 @@
     "webdriverio": "*"
   },
   "devDependencies": {
-    "@babel/register": "^7.13.8",
     "@typescript-eslint/eslint-plugin": "^4.14.0",
     "@typescript-eslint/parser": "^4.14.0",
-    "@wdio/cli": "^6.11.3",
-    "@wdio/local-runner": "^6.12.0",
-    "@wdio/mocha-framework": "^6.11.0",
-    "@wdio/spec-reporter": "^6.11.0",
-    "@wdio/sync": "^6.11.0",
+    "@wdio/cli": "^7.3.1",
+    "@wdio/local-runner": "^7.3.1",
+    "@wdio/mocha-framework": "^7.3.1",
+    "@wdio/spec-reporter": "^7.3.1",
+    "@wdio/sync": "^7.3.1",
     "chromedriver": "^89.0.0",
     "eslint": "^7.6.0",
     "kcd-scripts": "^5.0.0",
@@ -46,8 +45,7 @@
     "semantic-release": "^17.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3",
-    "wdio-chromedriver-service": "^6.0.4",
-    "webdriverio": "^6.12.0"
+    "wdio-chromedriver-service": "^7.0.0"
   },
   "repository": {
     "type": "git",

--- a/test/async/tsconfig.json
+++ b/test/async/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "webdriverio", "@wdio/mocha-framework"],
+    "types": ["node", "jest", "webdriverio/async", "@wdio/mocha-framework"],
     "baseUrl": "."
   },
   "exclude": [],

--- a/test/sync/tsconfig.json
+++ b/test/sync/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "types": ["node", "@wdio/sync", "@wdio/mocha-framework"]
+    "types": ["node", "jest", "webdriverio/sync", "@wdio/mocha-framework"]
   },
   "exclude": [],
   "include": ["**/*.ts"]

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -14,9 +14,16 @@ exports.config = {
   // Specify Test Files
   // ==================
   // Define which test specs should run. The pattern is relative to the directory
-  // from which `wdio` was called. Notice that, if you are calling `wdio` from an
-  // NPM script (see https://docs.npmjs.com/cli/run-script) then the current working
-  // directory is where your package.json resides, so `wdio` will be called from there.
+  // from which `wdio` was called.
+  //
+  // The specs are defined as an array of spec files (optionally using wildcards
+  // that will be expanded). The test for each spec file will be run in a separate
+  // worker process. In order to have a group of spec files run in the same worker
+  // process simply enclose them in an array within the specs array.
+  //
+  // If you are calling `wdio` from an NPM script (see https://docs.npmjs.com/cli/run-script),
+  // then the current working directory is where your `package.json` resides, so `wdio`
+  // will be called from there.
   //
   specs: ['./test/**/*.e2e.{js,ts}'],
   // Patterns to exclude.
@@ -114,7 +121,7 @@ exports.config = {
 
   // Framework you want to run your specs with.
   // The following are supported: Mocha, Jasmine, and Cucumber
-  // see also: https://webdriver.io/docs/frameworks.html
+  // see also: https://webdriver.io/docs/frameworks
   //
   // Make sure you have the wdio adapter package for the specific framework installed
   // before running any tests.
@@ -131,7 +138,7 @@ exports.config = {
   //
   // Test reporter for stdout.
   // The only one supported by default is 'dot'
-  // see also: https://webdriver.io/docs/dot-reporter.html
+  // see also: https://webdriver.io/docs/dot-reporter
   reporters: ['spec'],
 
   //
@@ -140,7 +147,6 @@ exports.config = {
   mochaOpts: {
     ui: 'bdd',
     timeout: 60000,
-    compiler: ['ts-node/register']
   },
   //
   // =====
@@ -184,9 +190,8 @@ exports.config = {
    * @param {Array.<String>} specs        List of spec file paths that are to be run
    * @param {Object}         browser      instance of created browser/device session
    */
-  before: function () {
-    require("@babel/register")({ extensions: ['.js', '.jsx', '.ts', '.tsx'] });
-  },
+  // before: function (capabilities, specs) {
+  // },
   /**
    * Runs before a WebdriverIO command gets executed.
    * @param {String} commandName hook command name


### PR DESCRIPTION
- update @wdio/cli to v7.3.1
- regenerate wdio.conf.js and install other deps using `wdio config`
- remove unnecessary @babel/register package
- add 'jest' to test tsconfig types as expect was no longer in the
global namespace