### PR TITLE
Add support for esm

### DIFF
--- a/.github/workflows/webdriverio-testing-library.yml
+++ b/.github/workflows/webdriverio-testing-library.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - 'master'
       - 'next'
+      - 'prerelease'
   pull_request:
 
 jobs:

--- a/package.json
+++ b/package.json
@@ -2,11 +2,14 @@
   "name": "@testing-library/webdriverio",
   "version": "1.0.1-semantically-released",
   "description": "",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "module": "./dist/esm/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "add-contributor": "kcd-scripts contributors add",
-    "build": "tsc -p tsconfig.build.json",
+    "build": "tsc -p tsconfig.build.json $npm_config_flags && tsc -p tsconfig.build.esm.json $npm_config_flags",
     "lint": "kcd-scripts lint",
     "test:unit": "kcd-scripts test --no-watch --config=jest.config.js",
     "validate": "kcd-scripts validate build,lint,test,typecheck",
@@ -14,12 +17,9 @@
     "semantic-release": "semantic-release",
     "typecheck:async": "tsc -p ./test/async/tsconfig.json",
     "typecheck:sync": "tsc -p ./test/sync/tsconfig.json",
-    "typecheck:build": "npm run build -- --noEmit",
+    "typecheck:build": "npm run build --flags='--noEmit'",
     "typecheck": "npm-run-all typecheck:build typecheck:**"
   },
-  "files": [
-    "dist"
-  ],
   "keywords": [],
   "author": "",
   "license": "ISC",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
   "release": {
     "branches": [
       "master",
-      "next"
+      "next",
+      {"name": "prerelease", "prerelease": true}
     ]
   },
   "publishConfig": {

--- a/tsconfig.build.esm.json
+++ b/tsconfig.build.esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.build.json",
+  "compilerOptions": {
+    "module": "ES2020",
+    "outDir": "./dist/esm",
+  },
+}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,8 +1,9 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "declaration": true,
-    "noEmit": false
+    "module": "commonjs",
+    "outDir": "./dist/cjs",
+    "noEmit": false,
   },
-  "exclude": ["test", "dist"]
+  "include": ["src"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,13 +2,13 @@
   "compilerOptions": {
     "baseUrl": ".",
     "target": "es2019",
-    "module": "commonjs",
     "strict": true,
     "esModuleInterop": true,
     "declaration": true,
     "outDir": "./dist",
     "skipLibCheck": true,
-    "noEmit": true
+    "noEmit": true,
+    "moduleResolution": "node"
   },
   "exclude": ["test"]
 }


### PR DESCRIPTION
- Add a prerelease branch "prerelease" so this can be iterated without incrementing the version number.
- Add a tsconfig to provide a dist for use in ESModules.
- Reorganise `dist` to have two folders `dist/cjs` and `dist/esm`
- Update `build` and related `typecheck:build` script to also build `dist/esm`
- Update package.json so "main" points to `dist/cjs` and "module" points to `dist/esm`
