### PR TITLE
fix: executing queries without chromedriver

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,9 +67,12 @@ function serializeArg(arg: any) {
 }
 
 function executeQuery(
-  [query, container, ...args]: [QueryName, HTMLElement, ...any[]],
-  done: (result: any) => void,
+  query: QueryName,
+  container: HTMLElement,
+  ...args: any[]
 ) {
+  const done = args.pop() as (result: any) => void;
+
   // @ts-ignore
   function deserializeObject(object) {
     return Object.entries(object)
@@ -124,7 +127,7 @@ function createQuery(element: ElementBase, queryName: string) {
   return async (...args: any[]) => {
     await injectDOMTestingLibrary(element)
 
-    const result = await element.executeAsync(executeQuery, [
+    const result = await element.executeAsync(executeQuery, ...[
       queryName,
       element,
       ...args.map(serializeArg),

--- a/src/index.ts
+++ b/src/index.ts
@@ -127,11 +127,12 @@ function createQuery(element: ElementBase, queryName: string) {
   return async (...args: any[]) => {
     await injectDOMTestingLibrary(element)
 
-    const result = await element.executeAsync(executeQuery, ...[
+    const result = await element.executeAsync(
+      executeQuery,
       queryName,
       element,
       ...args.map(serializeArg),
-    ])
+    )
 
     if (typeof result === 'string') {
       throw new Error(result)


### PR DESCRIPTION
The test suite on `master` currently fails if you remove the `services: ['chromedriver']` from `wdio.conf.js`.

[`executeAsync`](https://webdriver.io/docs/api/browser/executeAsync/) [expects args to be passed in position order](https://github.com/webdriverio/webdriverio/blob/625dc812f1679c8efbda0a3aeb875058eb9b0008/packages/webdriverio/src/commands/browser/executeAsync.ts#L46-L52). It captures them using the rest operator (...args).
The list of arguments is then passed to [`executeScriptAsync`](https://github.com/webdriverio/webdriverio/blob/625dc812f1679c8efbda0a3aeb875058eb9b0008/packages/devtools/src/commands/executeAsyncScript.ts#L34-L42) which transforms them.
 
The transformer checks the for the presence of the WebElement identifier. If it exists, it will transform it into a Puppeteer element handle. However, since the `arg` is a 2 dimensional array, [it does not perform the transformation, as the WebElement identifier property does not exist](https://github.com/webdriverio/webdriverio/blob/625dc812f1679c8efbda0a3aeb875058eb9b0008/packages/devtools/src/utils.ts#L191-L205).

As for why this works in Chromedriver.. 🤷