### PR TITLE
chore: remove Node 10 from test matrix

### DIFF
--- a/.github/workflows/webdriverio-testing-library.yml
+++ b/.github/workflows/webdriverio-testing-library.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: [12, 10]
+        node: [12]
     steps:
       - uses: nanasess/setup-chromedriver@master
         with:


### PR DESCRIPTION
Node 10 is currently end of life and is not supported by WebdriverIO v7.
In order to continue testing against recent versions of WebdriverIO
Node 10 needs to be dropped from the GitHub actions test matrix.