### PR TITLE
Refactor execute query

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -85,15 +85,13 @@ function executeQuery(
 ) {
   const done = args.pop() as (result: any) => void
 
-  // @ts-ignore
-  function deserializeObject(object) {
+  function deserializeObject(object: object): object {
     return Object.entries(object)
       .map(([key, value]) => [key, deserializeArg(value)])
       .reduce((acc, [key, value]) => ({...acc, [key]: value}), {})
   }
 
-  // @ts-ignore
-  function deserializeArg(arg) {
+  function deserializeArg(arg: any) {
     if (arg && arg.RegExp) {
       return eval(arg.RegExp)
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,30 +106,29 @@ function executeQuery(
 
   const [matcher, options, waitForOptions] = args.map(deserializeArg)
 
-  try {
-    Promise.resolve(
-      window.TestingLibraryDom[query](
+  ;(async () => {
+    let result: undefined | null | HTMLElement | HTMLElement[]
+    try {
+      result = await window.TestingLibraryDom[query](
         container,
         matcher,
         options,
         waitForOptions,
-      ),
-    )
-      .then((result) => {
-        if (!result) {
-          return done(null)
-        }
-        if (Array.isArray(result)) {
-          return done(
-            result.map((element) => ({selector: window.Simmer(element)})),
-          )
-        }
-        return done({selector: window.Simmer(result)})
-      })
-      .catch((e) => done(e.message))
-  } catch (e) {
-    done(e.message)
-  }
+      )
+    } catch (e) {
+      done(e.message)
+    }
+
+    if (!result) {
+      return done(null)
+    }
+
+    if (Array.isArray(result)) {
+      return done(result.map((element) => ({selector: window.Simmer(element)})))
+    }
+
+    return done({selector: window.Simmer(result)})
+  })()
 }
 
 function createQuery(element: ElementBase, queryName: string) {


### PR DESCRIPTION
- remove @ts-ignore comments from executeQuery

There is no reason to ignore the types when we can use loose types instead.

- catch getBy/findBy errors the same way

getBy queries throw an error whereas findBy queries reject a Promise.
This means we try-catch the query and chain a catch onto the promise
chain in order to handle both cases.

Instead we can use an async IIFE and try-catch the result of the query.
This handles both cases at once and allows us to flatten as an added
benefit.