### PR TITLE
test: increase timeout for delayed button elements

### DIFF
--- a/test-app/index.html
+++ b/test-app/index.html
@@ -152,7 +152,7 @@
         createButton('Unique Delayed Button Text')
         createButton('Delayed Button Text')
         createButton('Delayed Button Text')
-      }, 500)
+      }, 750)
 
       setTimeout(function () {
         createButton('Long Delayed Button Text')


### PR DESCRIPTION
The support waitFor options test is currently flaky, it could be that
the buttons are appearing too quickly for the test to pass reliably.
Increase the timeout of delayed buttons to 750ms, which is 250ms longer
than currently, but still below the default timeout that an async util
will wait of 1s.