### PR TITLE
fix: injecting DTL when amd define exists

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -37,6 +37,7 @@ const DOM_TESTING_LIBRARY_UMD_PATH = path.join(
 const DOM_TESTING_LIBRARY_UMD = fs
   .readFileSync(DOM_TESTING_LIBRARY_UMD_PATH)
   .toString()
+  .replace('define.amd', 'false') // Never inject DTL using AMD define function
 
 const SIMMERJS = fs
   .readFileSync(require.resolve('simmerjs/dist/simmer.js'))

--- a/test-app/index.html
+++ b/test-app/index.html
@@ -21,6 +21,10 @@
         content: 'Named by pseudo element';
       }
     </style>
+    <script>
+      define = function (){}
+      define.amd = {}
+    </script>
   </head>
 
   <div>


### PR DESCRIPTION
closes #34

https://www.ebay.com has a global define function with define.amd as an
empty object. This causes the UMD distribution of Dom Testing Library to
use the define function to expose it's methods. Since we assume the
methods are available on the TestingLibraryDom object this breaks the
library.

Modify the UMD distribution so it creates the TestingLibraryDom even
when a define function exists.