### PR TITLE
build: fix chromedriver version in CI

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -117,7 +117,12 @@ exports.config = {
   // Services take over a specific job you don't want to take care of. They enhance
   // your test setup with almost no effort. Unlike plugins, they don't add new
   // commands. Instead, they hook themselves up into the test process.
-  services: [['selenium-standalone', {drivers: {firefox: true, chrome: true}}]],
+  services: [
+    [
+      'selenium-standalone',
+      {drivers: {firefox: true, chrome: !process.env.CI || {version: '94'}}},
+    ],
+  ],
 
   // Framework you want to run your specs with.
   // The following are supported: Mocha, Jasmine, and Cucumber


### PR DESCRIPTION
GitHub Actions VMs have Chrome installed, but there is a period of time
after a new version is published that the machine is behind and builds
fail.

Specify the version used by GitHub Actions in our wdio.conf.js when CI
is true until a better solution can be used.

Ideally we'd either detect the correct version when running in CI or
install our own version of chrome-stable. These options are more
desirable than setting the Chrome version because we want to be aware of
bugs that come up with newer browser versions.