### PR TITLE
build: prevent chrome version mismatch in actions

### DIFF
--- a/.github/workflows/webdriverio-testing-library.yml
+++ b/.github/workflows/webdriverio-testing-library.yml
@@ -20,9 +20,13 @@ jobs:
           node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2
       - run: npm install
-      - run: npm run validate
+      - name: npm run validate
+        run: |
+          export CHROMEDRIVER_VERSION="$(chromedriver --version | awk '{print $2}')"
+          npm run validate
         env:
           CI: true
+
   release:
     runs-on: ubuntu-latest
     needs: test

--- a/wdio.conf.selenium-standalone.js
+++ b/wdio.conf.selenium-standalone.js
@@ -14,6 +14,14 @@ exports.config = {
     },
   ],
   services: [
-    ['selenium-standalone', {drivers: {firefox: true, chrome: true}}]
+    [
+      'selenium-standalone',
+      {
+        drivers: {
+          firefox: true,
+          chrome: process.env.CHROMEDRIVER_VERSION || true,
+        },
+      },
+    ],
   ],
 }


### PR DESCRIPTION
When using the default selenium-standalone Chromedriver version there is
a period of time where the Ubuntu container's Chrome version is behind
by a major version, this causes the tests to fail when using the
selenium-standalone service.

Find the version of Chromedriver that is on the container and then use
that to specify the Chromedriver version to use in the tests.