### PR TITLE
build: avoid failing actions from old chromedriver 

### DIFF
--- a/.github/workflows/webdriverio-testing-library.yml
+++ b/.github/workflows/webdriverio-testing-library.yml
@@ -19,10 +19,10 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
       - uses: actions/checkout@v2
-      - run: npm install
-      - name: npm run validate
+      - name: npm install and validate
         run: |
           export CHROMEDRIVER_VERSION="$(chromedriver --version | awk '{print $2}')"
+          npm install
           npm run validate
         env:
           CI: true

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "typecheck:async": "tsc -p ./test/async/tsconfig.json",
     "typecheck:sync": "tsc -p ./test/sync/tsconfig.json",
     "typecheck:build": "npm run build:cjs -- --noEmit && npm run build:esm -- --noEmit",
-    "typecheck": "npm-run-all typecheck:build typecheck:**"
+    "typecheck": "npm-run-all typecheck:build typecheck:**",
+    "prepare": "selenium-standalone install --drivers.chrome.version=${CHROMEDRIVER_VERSION:-latest} --drivers.gecko.version=${GECKODRIVER_VERSION:-latest}"
   },
   "files": [
     "dist"
@@ -49,13 +50,12 @@
     "@wdio/spec-reporter": "^7.19.0",
     "@wdio/sync": "^7.19.0",
     "eslint": "^7.6.0",
+    "geckodriver": "^3.2.0",
     "kcd-scripts": "^11.1.0",
     "npm-run-all": "^4.1.5",
     "semantic-release": "^17.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.4.2",
-    "chromedriver": "^105.0.1",
-    "geckodriver": "^3.0.2",
     "wdio-chromedriver-service": "^7.3.2",
     "wdio-geckodriver-service": "^2.0.0"
   },

--- a/wdio.conf.chromedriver.js
+++ b/wdio.conf.chromedriver.js
@@ -1,6 +1,23 @@
+const computeFsPaths = require('selenium-standalone/lib/compute-fs-paths');
+const createDefaultOps = require('selenium-standalone/lib/default-config');
+
 const baseConfig = require('./wdio.conf')
+const defaultOps = createDefaultOps()
+
+const fsPaths = computeFsPaths({
+  ...defaultOps,
+  seleniumVersion: defaultOps.version,
+  drivers: {
+    chrome: {
+      version: process.env.CHROMEDRIVER_VERSION || 'latest',
+      arch: process.arch,
+    },
+  },
+})
 
 exports.config = {
   ...baseConfig.config,
-  services: ['chromedriver'],
+  services: [
+    ['chromedriver', {chromedriverCustomPath: fsPaths.chrome.installPath}],
+  ],
 }

--- a/wdio.conf.geckodriver.js
+++ b/wdio.conf.geckodriver.js
@@ -1,16 +1,33 @@
+const computeFsPaths = require('selenium-standalone/lib/compute-fs-paths')
+const createDefaultOps = require('selenium-standalone/lib/default-config')
+
 const baseConfig = require('./wdio.conf')
+const defaultOps = createDefaultOps()
+
+const fsPaths = computeFsPaths({
+  ...defaultOps,
+  seleniumVersion: defaultOps.version,
+  drivers: {
+    firefox: {
+      version: process.env.GECKODRIVER_VERSION || 'latest',
+      arch: process.arch,
+    },
+  },
+})
 
 exports.config = {
   ...baseConfig.config,
-  services: ['geckodriver'],
+  services: [
+    ['geckodriver', {geckodriverCustomPath: fsPaths.firefox.installPath}],
+  ],
   capabilities: [
     {
       maxInstances: 5,
       browserName: 'firefox',
       acceptInsecureCerts: true,
       'moz:firefoxOptions': {
-        args: process.env.CI ? ['--headless'] : [],
+        args: process.env.CI ? ['-headless'] : [],
       },
     },
-  ]
+  ],
 }

--- a/wdio.conf.selenium-standalone.js
+++ b/wdio.conf.selenium-standalone.js
@@ -18,7 +18,7 @@ exports.config = {
       'selenium-standalone',
       {
         drivers: {
-          firefox: true,
+          firefox: process.env.GECKODRIVER_VERSION || true,
           chrome: process.env.CHROMEDRIVER_VERSION || true,
         },
       },


### PR DESCRIPTION
When the GitHub actions chrome version is updated there is not an easy
way to update the version of Chromedriver in the package.json to match.

Remove chromedriver from dev dependencies and instead use the version
that is installed by selenium-standalone when running chromedriver tests
locally.

Ensure the correct version is installed in CI by specifying which
version of chromedriver to install in the prepare script.